### PR TITLE
Create cmx.thedev.me.json

### DIFF
--- a/domains/cmx.thedev.me.json
+++ b/domains/cmx.thedev.me.json
@@ -1,0 +1,13 @@
+{
+  "subdomain": "cmx",
+  "domain": "thedev.me",
+  "email_or_discord": "admin@cmx.im",
+  "github_username": "cmx-im",
+  "description": "Alt domain for the CMX.im Mastodon/Fediverse Community",
+
+  "records": {
+    "CNAME": ["s1.cmx.edu.kg"]
+  },
+
+  "proxied": true
+}


### PR DESCRIPTION
This PR is to request the subdomain cmx.thedev.me to be used as an alternate domain for our Mastodon Chinese instance, which provides a platform for Chinese users to engage freely and openly in discussions.

Our project, CMX.im or Mastodon Chinese (https://cmx-im.github.io/), is one of the most popular Chinese instance of Mastodon. Mastodon is an open-source, decentralized social network that adheres to the ActivityPub and GNU Social protocol, and the entire Mastodon community consists of many instances.

We strictly adhere to the [Mastodon Server Covenant](https://joinmastodon.org/covenant), which includes active moderation policies against racism, sexism, homophobia, and transphobia, ensuring a safe and inclusive environment for all our users.

The community was featured in a Wall Street Journal piece, along with other similar Mastodon communities. For details: [WSJ Feature](https://www.wsj.com/podcasts/google-news-update/more-of-chinas-social-media-users-head-to-under-the-radar-platforms/8df97b43-c2fc-449b-9160-2c7680e1d14d). As highlighted in the article, we are dedicated to promoting free speech for Chinese users while offering a decentralized, open-source alternative to mainstream social media platforms.

We believe that providing an alternative domain such as cmx.thedev.me will make it easier for users to access our platform securely and conveniently.

Thank you for your time and consideration.