### PR TITLE
Add kenerst.thedev.me (Kenerst Express)

### DIFF
--- a/domains/kenerst.thedev.me.json
+++ b/domains/kenerst.thedev.me.json
@@ -1,0 +1,11 @@
+{
+  "subdomain": "kenerst",
+  "domain": "thedev.me",
+  "email_or_discord": "darko.ernestoffei@gmail.com",
+  "github_username": "sololunar",
+  "description": "Kenerst Express — premium online shop",
+  "records": {
+    "CNAME": ["sololunar.github.io"]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Requesting subdomain kenerst.thedev.me

This PR adds the JSON file for Kenerst Express shop.
The site will be hosted on GitHub Pages (sololunar.github.io).
Contact: darko.ernestoffei@gmail.com