### PR TITLE
Add configuration file for ERP demo site details

### DIFF
--- a/domains/erp.thedev.me.json
+++ b/domains/erp.thedev.me.json
@@ -7,5 +7,5 @@
   "records": {
     "A": ["116.63.178.245"]
   },
-  "proxied": true
+  "proxied": false
 }

--- a/domains/erp.thedev.me.json
+++ b/domains/erp.thedev.me.json
@@ -1,0 +1,11 @@
+{
+  "subdomain": "erp",
+  "domain": "thedev.me",
+  "email_or_discord": "steveyi168@gmail.com",
+  "github_username": "steve-gmail",
+  "description": "ERP platform demo site for testing",
+  "records": {
+    "A": ["116.63.178.245"]
+  },
+  "proxied": true
+}


### PR DESCRIPTION
This configuration file includes details for the ERP demo site, such as the subdomain, domain, and associated records.