### PR TITLE
Add JSON configuration for daytrevisan subdomain

### DIFF
--- a/domains/daytrevisan.thedev.me.json
+++ b/domains/daytrevisan.thedev.me.json
@@ -1,0 +1,11 @@
+{
+  "subdomain": "daytrevisan",
+  "domain": "thedev.me",
+  "email_or_discord": "daytrevisan",
+  "github_username": "daytrevisan",
+  "description": "My portfolio as dev",
+  "records": {
+    "CNAME": ["daytrevisan.github.io"]
+  },
+  "proxied": true
+}


### PR DESCRIPTION
This pull request adds a new domain configuration for the subdomain `daytrevisan.thedev.me`, setting up DNS records and related metadata for a developer portfolio.

Domain setup:

* Added a new JSON file `domains/daytrevisan.thedev.me.json` to configure the subdomain `daytrevisan.thedev.me` with a CNAME record pointing to `daytrevisan.github.io`, along with metadata such as GitHub username and description.